### PR TITLE
add url to corss

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ app.use('/api', limiter);
 // CORS configuration
 app.use(cors({
   origin: process.env.NODE_ENV === 'production' 
-    ? ['https://your-frontend-domain.com'] 
+    ? ['https://channelzero-server.balaji648balaji.workers.dev/'] 
     : ['http://localhost:5173', 'http://localhost:5174', 'http://127.0.0.1:5173', 'http://127.0.0.1:5174'],
   credentials: true
 }));


### PR DESCRIPTION
This pull request updates the CORS configuration for the server to specify the correct frontend domain in production.

Configuration update:

* Changed the production CORS `origin` to use `https://channelzero-server.balaji648balaji.workers.dev/` instead of the placeholder domain, ensuring only requests from the correct frontend are allowed.