### PR TITLE
fixed url to corss

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,7 +30,7 @@ app.use('/api', limiter);
 // CORS configuration
 app.use(cors({
   origin: process.env.NODE_ENV === 'production' 
-    ? ['https://channelzero-server.balaji648balaji.workers.dev/'] 
+    ? ['https://channelzero.pages.dev/'] 
     : ['http://localhost:5173', 'http://localhost:5174', 'http://127.0.0.1:5173', 'http://127.0.0.1:5174'],
   credentials: true
 }));


### PR DESCRIPTION
This pull request updates the CORS configuration to reflect a new production frontend domain. The change ensures that only requests from the correct production origin are allowed.

CORS configuration update:

* Changed the allowed production origin in the CORS middleware from `https://channelzero-server.balaji648balaji.workers.dev/` to `https://channelzero.pages.dev/` in `server/index.js`.